### PR TITLE
ci: add github workflows and templates

### DIFF
--- a/project_template/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/project_template/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop, server, or mobile):
+* Link to your project:

--- a/project_template/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/project_template/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the feature request in the Title above -->
+
+## Expected Behavior
+<!--- A clear and concise description of what you want to happen -->
+
+## Current Behavior
+<!--- Explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Suggest ideas of how to implement the addition or change -->
+
+## Alternatives Considered
+<!--- A clear and concise description of any alternative solutions or features you've considered -->
+
+## Additional Context
+<!--- Add any other context or screenshots about the feature request here. -->
+
+

--- a/project_template/.github/PULL_REQUEST_TEMPLATE.md
+++ b/project_template/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
+
+## Issue being fixed or feature implemented
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+
+## What was done?
+<!--- Describe your changes in detail -->
+
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+
+## Breaking Changes
+<!--- Please describe any breaking changes your code introduces and verify that -->
+<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
+
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have added or updated relevant unit/integration/functional/e2e tests
+- [ ] I have made corresponding changes to the documentation
+
+**For repository code-owners and collaborators only**
+- [ ] I have assigned this pull request to a milestone

--- a/project_template/.github/workflows/dapi-grpc.yml
+++ b/project_template/.github/workflows/dapi-grpc.yml
@@ -1,0 +1,23 @@
+name: DAPI GRPC Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '41 */160 * * *'
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+\.[0-9]+-dev
+    paths:
+      - packages/dapi-grpc/**
+      - .github/workflows/dapi-grpc.yml
+
+jobs:
+  dapi-grpc-tests:
+    name: Run DAPI GRPC tests
+    uses: strophy/monoproject/.github/workflows/test.yml@master
+    with:
+      package: '@dashevo/dapi-grpc'

--- a/project_template/.github/workflows/dpns-contract.yml
+++ b/project_template/.github/workflows/dpns-contract.yml
@@ -1,0 +1,23 @@
+name: DPNS Contract Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '41 */160 * * *'
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+\.[0-9]+-dev
+    paths:
+      - packages/dpns-contract/**
+      - .github/workflows/dpns-contract.yml
+
+jobs:
+  dpns-contract-tests:
+    name: Run DPNS Contract tests
+    uses: strophy/monoproject/.github/workflows/test.yml@master
+    with:
+      package: '@dashevo/dpns-contract'

--- a/project_template/.github/workflows/feature-flags-contract.yml
+++ b/project_template/.github/workflows/feature-flags-contract.yml
@@ -1,0 +1,23 @@
+name: Feature Flags Contract Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '41 */160 * * *'
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+\.[0-9]+-dev
+    paths:
+      - packages/feature-flags-contract/**
+      - .github/workflows/feature-flags-contract.yml
+
+jobs:
+  feature-flags-contract-tests:
+    name: Run DAPI Client tests
+    uses: strophy/monoproject/.github/workflows/test.yml@master
+    with:
+      package: '@dashevo/feature-flags-contract'

--- a/project_template/.github/workflows/js-abci.yml
+++ b/project_template/.github/workflows/js-abci.yml
@@ -1,0 +1,23 @@
+name: JS ABCI Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '41 */160 * * *'
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+\.[0-9]+-dev
+    paths:
+      - packages/js-abci/**
+      - .github/workflows/js-abci.yml
+
+jobs:
+  js-abci-tests:
+    name: Run JS ABCI tests
+    uses: strophy/monoproject/.github/workflows/test.yml@master
+    with:
+      package: '@dashevo/abci'

--- a/project_template/.github/workflows/js-dapi-client.yml
+++ b/project_template/.github/workflows/js-dapi-client.yml
@@ -1,0 +1,23 @@
+name: JS DAPI Client Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '41 */160 * * *'
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+\.[0-9]+-dev
+    paths:
+      - packages/js-dapi-client/**
+      - .github/workflows/js-dapi-client.yml
+
+jobs:
+  js-dapi-client-tests:
+    name: Run JS DAPI Client tests
+    uses: strophy/monoproject/.github/workflows/test.yml@master
+    with:
+      package: '@dashevo/dapi-client'

--- a/project_template/.github/workflows/js-dpp.yml
+++ b/project_template/.github/workflows/js-dpp.yml
@@ -1,0 +1,23 @@
+name: JS-DPP Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '41 */160 * * *'
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+\.[0-9]+-dev
+    paths:
+      - packages/js-dpp/**
+      - .github/workflows/js-dpp.yml
+
+jobs:
+  js-dpp-tests:
+    name: Run DPP tests
+    uses: strophy/monoproject/.github/workflows/test.yml@master
+    with:
+      package: '@dashevo/dpp'

--- a/project_template/.github/workflows/js-grpc-common.yml
+++ b/project_template/.github/workflows/js-grpc-common.yml
@@ -1,0 +1,23 @@
+name: JS GRPC Common Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '41 */160 * * *'
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+\.[0-9]+-dev
+    paths:
+      - packages/js-grpc-common/**
+      - .github/workflows/js-grpc-common.yml
+
+jobs:
+  js-grpc-common-tests:
+    name: Run JS GRPC Common tests
+    uses: strophy/monoproject/.github/workflows/test.yml@master
+    with:
+      package: '@dashevo/grpc-common'

--- a/project_template/.github/workflows/release.yml
+++ b/project_template/.github/workflows/release.yml
@@ -1,0 +1,147 @@
+name: Release Packages
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release-npm:
+    name: Release Dash Platform to NPM
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.1.1
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Run Platform Test Suite'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 60
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Enable NPM cache
+        uses: actions/cache@v2
+        with:
+          path: '~/.npm'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Set release tag
+        uses: actions/github-script@v5
+        id: tag
+        with:
+          result-encoding: string
+          script: |
+            const tag = context.payload.release.tag_name;
+            const [, major, minor] = tag.match(/^v([0-9]+)\.([0-9]+)/);
+            return (tag.includes('dev') ? `${major}.${minor}-dev` : 'latest');
+
+      - name: Publish NPM package
+        run: npm publish --workspaces --tag ${{ steps.tag.outputs.result }}
+
+  release-docker:
+    name: Release Dash Platform to Docker Hub
+    runs-on: ubuntu-20.04
+    needs: release-npm
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker BuildX
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: v0.6.3
+          install: true
+          driver-opts: image=moby/buildkit:buildx-stable-1
+
+      - name: Enable buildkit cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/buildkit-cache/buildkit-state.tar
+          key: ${{ runner.os }}-buildkit-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildkit-
+
+      - name: Load buildkit state from cache
+        uses: dashevo/gh-action-cache-buildkit-state@v1
+        with:
+          builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
+          cache-path: /tmp/buildkit-cache
+          cache-max-size: 2g
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set suffix to Docker tags
+        uses: actions/github-script@v5
+        id: suffix
+        with:
+          result-encoding: string
+          script: "return (context.payload.release.tag_name.includes('-dev') ? '-dev' : '');"
+
+      - name: Set Docker tags and labels for DAPI
+        id: dapi_docker_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: dashpay/dapi
+          tags: |
+            type=match,pattern=v(\d+),group=1
+            type=match,pattern=v(\d+.\d+),group=1
+            type=match,pattern=v(\d+.\d+.\d+),group=1
+            type=match,pattern=v(.*),group=1,suffix=,enable=${{ contains(github.event.release.tag_name, '-dev') }}
+          flavor: |
+            latest=${{ !contains(github.event.release.tag_name, '-dev') }}
+            suffix=${{ steps.suffix.outputs.result }}
+
+      - name: Build and push Docker image for DAPI
+        id: dapi_docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./dapi
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./dapi/Dockerfile
+          push: true
+          tags: ${{ steps.dapi_docker_meta.outputs.tags }}
+          labels: ${{ steps.dapi_docker_meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set Docker tags and labels for Drive
+        id: drive_docker_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: dashpay/dapi
+          tags: |
+            type=match,pattern=v(\d+),group=1
+            type=match,pattern=v(\d+.\d+),group=1
+            type=match,pattern=v(\d+.\d+.\d+),group=1
+            type=match,pattern=v(.*),group=1,suffix=,enable=${{ contains(github.event.release.tag_name, '-dev') }}
+          flavor: |
+            latest=${{ !contains(github.event.release.tag_name, '-dev') }}
+            suffix=${{ steps.suffix.outputs.result }}
+
+      - name: Build and push Docker image for Drive
+        id: drive_docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./drive
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./drive/Dockerfile
+          push: true
+          tags: ${{ steps.drive_docker_meta.outputs.tags }}
+          labels: ${{ steps.drive_docker_meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/project_template/.github/workflows/test-suite.yml
+++ b/project_template/.github/workflows/test-suite.yml
@@ -1,0 +1,66 @@
+name: Platform Test Suite
+
+on:
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+\.[0-9]+-dev
+
+jobs:
+  test:
+    name: Run Platform Test Suite
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Set up Docker BuildX
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: v0.6.3
+          install: true
+          driver-opts: image=moby/buildkit:buildx-stable-1
+
+      - name: Enable NPM cache
+        uses: actions/cache@v2
+        with:
+          path: '~/.npm'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Enable buildkit cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/buildkit-cache/buildkit-state.tar
+          key: ${{ runner.os }}-buildkit-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildkit-
+
+      - name: Load buildkit state from cache
+        uses: dashevo/gh-action-cache-buildkit-state@v1
+        with:
+          builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
+          cache-path: /tmp/buildkit-cache
+          cache-max-size: 2g
+
+      - name: Check NPM package lock version is updated
+        uses: dashevo/gh-action-check-package-lock@v1
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Run test suite
+        run: npm run setup_and_test

--- a/project_template/.github/workflows/test.yml
+++ b/project_template/.github/workflows/test.yml
@@ -47,4 +47,6 @@ jobs:
         run: echo "::set-output name=dependants::$(packster list ${{ inputs.package }} --json)"
 
       - name: Run tests on packages
-        run: ./scripts/run_tests.sh '${{ steps.packster.outputs.dependants }}'
+        run: |
+          ./scripts/configure_dotenv.sh
+          ./scripts/run_tests.sh '${{ steps.packster.outputs.dependants }}'

--- a/project_template/.github/workflows/test.yml
+++ b/project_template/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm install -g packster
 
       - name: Run Packster
-        run: packster check ${{ inputs.package }} --error
+        run: packster check --all --error
 
       - name: Run ESLinter
         run: npm run lint -w ${{ inputs.package }}

--- a/project_template/.github/workflows/test.yml
+++ b/project_template/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Package Tests
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: The calling package
+        type: string
+        default: .
+
+jobs:
+  test:
+    name: Test Dash Platform component
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Enable NPM cache
+        uses: actions/cache@v2
+        with:
+          path: '~/.npm'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Install Packster
+        run: npm install -g packster
+
+      - name: Run Packster
+        run: packster check ${{ inputs.package }} --error
+
+      - name: Run ESLinter
+        run: npm run lint -w ${{ inputs.package }}
+
+      - name: Get list of packages to test
+        id: packster
+        run: echo "::set-output name=dependants::$(packster list ${{ inputs.package }} --json)"
+
+      - name: Run tests on packages
+        run: ./scripts/run_tests.sh '${{ steps.packster.outputs.dependants }}'


### PR DESCRIPTION
I'm not sure how we should reference the workflow, it's currently this:

`strophy/monoproject/.github/workflows/test.yml@master`

`strophy` -> `antouhou` -> `dashevo` makes sense as we work on this, but should it always run `master` workflow, or the workflow from the current branch?